### PR TITLE
Make SpdxExpression implement Hash.

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Main struct for SPDX License Expressions.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SpdxExpression {
     /// The parsed expression.
     inner: ExpressionVariant,

--- a/src/expression_variant.rs
+++ b/src/expression_variant.rs
@@ -140,7 +140,7 @@ impl SimpleExpression {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WithExpression {
     pub license: SimpleExpression,
     pub exception: String,
@@ -163,7 +163,7 @@ impl Display for WithExpression {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash)]
 pub enum ExpressionVariant {
     Simple(SimpleExpression),
     With(WithExpression),


### PR DESCRIPTION
This is only for exact equality: there are ways to make *equivalent* expressions that are not equal and do not hash the same.

When spdx-rs switched FileInformation to contain SpdxExpression instead of SimpleExpression, it broke my tool because it no longer implemented Hash.
